### PR TITLE
fixed descriptor keying when the host application uses different resources per bufferedFrameIndex

### DIFF
--- a/Integration/NRDIntegration.h
+++ b/Integration/NRDIntegration.h
@@ -83,7 +83,7 @@ private:
 
     void CreateResources();
     void AllocateAndBindMemory();
-    void Dispatch(nri::CommandBuffer& commandBuffer, nri::DescriptorPool& descriptorPool,
+    void Dispatch(uint32_t bufferedFrameIndex, nri::CommandBuffer& commandBuffer, nri::DescriptorPool& descriptorPool,
         const nrd::DispatchDesc& dispatchDesc, const NrdUserPool& userPool);
 
 private:


### PR DESCRIPTION
This fix adds the buffered frame index to the descriptor key to prevent NrdIntegration from using resources from different frames. Alternatively m_Descriptors could be divided into per-descriptorpool maps