### PR TITLE
fix: update CMakeLists.txt to fetch ShaderMake from specific tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,7 @@ if(NOT TARGET ShaderMake AND NOT NRD_DISABLE_SHADER_COMPILATION)
     FetchContent_Declare(
         shadermake
         GIT_REPOSITORY https://github.com/NVIDIA-RTX/ShaderMake.git
-        GIT_TAG main
-        GIT_SHALLOW 1
+        GIT_TAG 674e713091cf76b4b9c9c67eb094ba3fd440f306
     )
     list(APPEND DEPS shadermake)
 endif()


### PR DESCRIPTION
ShaderMake building is currently broken due to recent changes in [this commit](https://github.com/NVIDIA-RTX/ShaderMake/commit/b4abd0e8379b1906461a730429258c902cc99e0a). As a fix, pin to a specific Git tag.