### PR TITLE
set the vk image usage flags

### DIFF
--- a/Integration/NRDIntegration.hpp
+++ b/Integration/NRDIntegration.hpp
@@ -684,6 +684,7 @@ void Integration::DenoiseVK(const Identifier* denoisers, uint32_t denoisersNum, 
         textureDesc.vkImage = resource.vk.image;
         textureDesc.vkFormat = resource.vk.format;
         textureDesc.vkImageType = 1; // VK_IMAGE_TYPE_2D
+        textureDesc.vkImageUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
         textureDesc.width = m_Desc.resourceWidth;
         textureDesc.height = m_Desc.resourceHeight;
         textureDesc.depth = 1;


### PR DESCRIPTION
nrd currently does not set the image usage flags for snapshotted resources. this causes nri to fail to validate the textures when creating a view (see https://github.com/NVIDIA-RTX/NRI/blob/main/Source/Validation/DeviceVal.hpp#L319)

this change adds the sampled image and storage image usage bits to snapshot images, and lets nrd run without validation errors